### PR TITLE
fix: updates navidrome-deployer chart repo name

### DIFF
--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -13,7 +13,7 @@ releases:
   createNamespace: true
 - name: navidrome
   namespace: navidrome-system
-  chart: navidrome-deployer
+  chart: navidrome/navidrome-deployer
   version: 0.7.0
   createNamespace: true
   needs:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update Helmfile to use the fully qualified chart name navidrome/navidrome-deployer for the Navidrome release. This fixes chart resolution errors and ensures installs and upgrades succeed.

<sup>Written for commit 69181b355d869f7e6cbf7b1744a5c9bdbd5c8d5e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

