### PR TITLE
chore: adds installation instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,18 @@ Before deploying `navidrome-deployer`, ensure the following tools are installed:
 - [helm](https://helm.sh/docs/intro/install/) - Kubernetes package manager
 - [helmfile](https://github.com/roboll/helmfile#installation) - Helm values file manager
 
-## Local Deployment
+## Installation on a cluster
+To install the latest release
+```bash
+helmfile apply -f https://github.com/semmet95/navidrome-deployer/releases/latest/download/helmfile.yaml
+```
+
+To install a specific version
+```bash
+helmfile apply -f https://github.com/semmet95/navidrome-deployer/releases/download/<version>/helmfile.yaml
+```
+
+## Local Setup and Deployment
 
 To deploy navidrome-deployer locally, execute the following command:
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add cluster installation instructions to the README with helmfile apply commands for latest and specific versions. Rename the local section to "Local Setup and Deployment" for clarity.

<sup>Written for commit dde02c3bd5c4deb0b7146a0b54d35c8bb3c3e4f5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

