### PR TITLE
chore: bumps up navidrom chart version

### DIFF
--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -14,7 +14,7 @@ releases:
 - name: navidrome
   namespace: navidrome-system
   chart: navidrome/navidrome-deployer
-  version: 0.7.0
+  version: 0.8.0
   createNamespace: true
   needs:
   - longhorn-system/longhorn


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update navidrome/navidrome-deployer Helm chart from 0.7.0 to 0.8.0 to deploy the latest fixes and improvements. This will upgrade the navidrome release on the next helmfile apply.

<sup>Written for commit c6ba04fcb977389dae933c5bb643b25931f3a21a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

