### PR TITLE
feat: adds pod anti affinity

### DIFF
--- a/charts/navidrome-deployer/templates/deployment.yml
+++ b/charts/navidrome-deployer/templates/deployment.yml
@@ -17,6 +17,18 @@ spec:
         {{- include "commonLabels" . | nindent 8 }}
         app: navidrome
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - navidrome
+              topologyKey: kubernetes.io/hostname
       containers:
       - name: navidrome
         image: {{ .Values.image.repo }}:{{ .Values.image.tag }}

--- a/scripts/test-setup.sh
+++ b/scripts/test-setup.sh
@@ -15,5 +15,8 @@ else
     exit 1
 fi
 
-sudo curl -sfL https://get.k3s.io | sh -s - server --disable traefik --disable servicelb --disable metrics-server --disable-cloud-controller
+sudo curl -sfL https://get.k3s.io | sh -s - server \
+    --disable-cloud-controller \
+    --disable=servicelb \
+    --etcd-disable-snapshots
 sudo chmod 644 /etc/rancher/k3s/k3s.yaml


### PR DESCRIPTION
Fixes: #29 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add pod anti-affinity to Navidrome so replicas spread across nodes, addressing #29. Update k3s test setup to disable etcd snapshots and adjust defaults.

- **New Features**
  - Add preferred podAntiAffinity for app=navidrome (topology: kubernetes.io/hostname, weight 100) to prefer pods on different nodes.

- **Refactors**
  - Update test-setup.sh k3s flags: keep cloud-controller and servicelb disabled, stop disabling traefik and metrics-server, disable etcd snapshots.

<sup>Written for commit 14d522a188890aeb928ad5f825be57f2197f1f9b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

