### PR TITLE
chore: whitelists k3s in firewall service

### DIFF
--- a/charts/navidrome-deployer/Chart.yaml
+++ b/charts/navidrome-deployer/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: navidrome-deployer
 description: A Helm chart for deploying Navidrome music server
-version: 0.9.0
+version: 0.10.0
 appVersion: "0.58.5"

--- a/scripts/test-setup.sh
+++ b/scripts/test-setup.sh
@@ -4,12 +4,17 @@ set -ex
 # K3S setup
 if [ -f /etc/redhat-release ]; then
     sudo dnf install -y kernel-modules-extra
-    systemctl disable firewalld --now
+    sudo firewall-cmd --permanent --add-port=6443/tcp #apiserver
+    sudo firewall-cmd --permanent --zone=trusted --add-source=10.42.0.0/16 #pods
+    sudo firewall-cmd --permanent --zone=trusted --add-source=10.43.0.0/16 #services
+    sudo firewall-cmd --reload
 elif [ -f /etc/debian_version ]; then
     # the following changes are relevant for free tier GA runners
-    sudo ufw disable
     sudo apt-get update
     sudo apt-get install -y nfs-common
+    sudo ufw allow 6443/tcp #apiserver
+    sudo ufw allow from 10.42.0.0/16 to any #pods
+    sudo ufw allow from 10.43.0.0/16 to any #services
 else
     echo "Host OS not supported"
     exit 1


### PR DESCRIPTION
Fixes: #21 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Whitelist k3s traffic in test-setup so clusters start with firewalls enabled on RHEL and Debian. Bump navidrome-deployer chart to 0.10.0.

- **Bug Fixes**
  - RHEL: open 6443/tcp; trust 10.42.0.0/16 (pods) and 10.43.0.0/16 (services); reload firewalld.
  - Debian: open 6443/tcp; allow 10.42.0.0/16 and 10.43.0.0/16 via ufw.
  - Keep firewalld/ufw enabled; allow k3s networking.

<sup>Written for commit cbfab12f5c41b3d1b2a0999fd984d295ec47debf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

