### PR TITLE
feat: pushes filebrowser-reconfig image to ghcr registry

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -54,6 +54,12 @@ jobs:
             https://github.com/$IMAGE_NAME/releases/download/${{ github.event.repository.name }}-${{ steps.chart-metadata.outputs.version }}/${{ steps.chart-metadata.outputs.name }}-${{ steps.chart-metadata.outputs.version }}.tgz
           helm push ./${{ steps.chart-metadata.outputs.name }}-${{ steps.chart-metadata.outputs.version }}.tgz \
             "oci://$REGISTRY/$IMAGE_NAME/charts"
+      - name: Push filebrowser-config image
+        run: |
+          set -e
+          image_tag="$REGISTRY/$IMAGE_NAME/filebrowser-reconfig:${{ steps.chart-metadata.outputs.version }}"
+          docker build -t "$image_tag" . -f Dockerfile.filebrowser
+          docker push "$image_tag"
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:


### PR DESCRIPTION
Fixes: #40 

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a release workflow step to build and publish the filebrowser-reconfig Docker image to GHCR, tagged with the chart version. Ensures the image is available alongside chart releases.

- **New Features**
  - Builds image from Dockerfile.filebrowser and tags it as $REGISTRY/$IMAGE_NAME/filebrowser-reconfig:${{ steps.chart-metadata.outputs.version }}.
  - Pushes the image to GHCR during the package release job.

<sup>Written for commit 20e923a45c23da342ada965082c30d254e0f360e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

