### PR TITLE
fix: runs navidrome container as root

### DIFF
--- a/charts/navidrome-deployer/Chart.yaml
+++ b/charts/navidrome-deployer/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: navidrome-deployer
 description: A Helm chart for deploying Navidrome music server
-version: 0.21.0
+version: 0.21.1
 appVersion: "v0.60.3"

--- a/charts/navidrome-deployer/templates/deployment.yml
+++ b/charts/navidrome-deployer/templates/deployment.yml
@@ -47,6 +47,8 @@ spec:
             cpu: {{ .Values.resources.requests.cpu }}
           limits:
             memory: {{ .Values.resources.limits.memory }}
+        securityContext:
+          runAsUser: 0
         volumeMounts:
         - name: data-volume
           mountPath: /data

--- a/charts/navidrome-deployer/values.yaml
+++ b/charts/navidrome-deployer/values.yaml
@@ -26,7 +26,7 @@ certificate:
 
 filebrowser:
   imageURI: "filebrowser/filebrowser:v2.61.0"
-  reconfigImageUri: "ghcr.io/semmet95/navidrome-deployer/filebrowser-reconfig:0.21.0"
+  reconfigImageUri: "ghcr.io/semmet95/navidrome-deployer/filebrowser-reconfig:0.21.1"
   containerPort: 80
   resources:
     limits:

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -39,7 +39,7 @@ releases:
 - name: navidrome
   namespace: navidrome-system
   chart: navidrome/navidrome-deployer
-  version: 0.21.0
+  version: 0.21.1
   createNamespace: true
   disableValidationOnInstall: true
   needs:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Run the Navidrome container as root to fix permission issues during startup and file writes.
Update the Helm chart, helmfile release, and filebrowser reconfig image to 0.21.1 to reflect the change.

<sup>Written for commit 65297ef6346058b27b3209b8b5c9a860d9dd918f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

