### PR TITLE
fix: increases navidrome scan frequency

### DIFF
--- a/charts/navidrome-deployer/Chart.yaml
+++ b/charts/navidrome-deployer/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: navidrome-deployer
 description: A Helm chart for deploying Navidrome music server
-version: 0.21.1
+version: 0.21.2
 appVersion: "v0.60.3"

--- a/charts/navidrome-deployer/templates/config.yml
+++ b/charts/navidrome-deployer/templates/config.yml
@@ -8,4 +8,4 @@ metadata:
     {{- include "appLabels" . | nindent 4 }}
 data:
   ND_ENABLEUSEREDITING: "false"
-  ND_SCANNER_SCHEDULE: "*/2 * * * *"
+  ND_SCANNER_SCHEDULE: "*/1 * * * *"

--- a/charts/navidrome-deployer/templates/deployment.yml
+++ b/charts/navidrome-deployer/templates/deployment.yml
@@ -47,8 +47,6 @@ spec:
             cpu: {{ .Values.resources.requests.cpu }}
           limits:
             memory: {{ .Values.resources.limits.memory }}
-        securityContext:
-          runAsUser: 0
         volumeMounts:
         - name: data-volume
           mountPath: /data

--- a/charts/navidrome-deployer/values.yaml
+++ b/charts/navidrome-deployer/values.yaml
@@ -26,7 +26,7 @@ certificate:
 
 filebrowser:
   imageURI: "filebrowser/filebrowser:v2.61.0"
-  reconfigImageUri: "ghcr.io/semmet95/navidrome-deployer/filebrowser-reconfig:0.21.1"
+  reconfigImageUri: "ghcr.io/semmet95/navidrome-deployer/filebrowser-reconfig:0.21.2"
   containerPort: 80
   resources:
     limits:

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -39,7 +39,7 @@ releases:
 - name: navidrome
   namespace: navidrome-system
   chart: navidrome/navidrome-deployer
-  version: 0.21.1
+  version: 0.21.2
   createNamespace: true
   disableValidationOnInstall: true
   needs:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Increase Navidrome scanner schedule to run every minute to pick up new files faster. Also bump chart to 0.21.2, update the filebrowser reconfig image to 0.21.2, and remove runAsUser: 0 from the deployment.

<sup>Written for commit 2bbe10333a1e6ada15d4d6b37792fd104650aef7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

