### PR TITLE
feat: adds feature flag to disable public exposure

### DIFF
--- a/charts/navidrome-deployer/Chart.yaml
+++ b/charts/navidrome-deployer/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: navidrome-deployer
 description: A Helm chart for deploying Navidrome music server
-version: 0.21.2
+version: 0.22.0
 appVersion: "v0.60.3"

--- a/charts/navidrome-deployer/templates/certificate.yml
+++ b/charts/navidrome-deployer/templates/certificate.yml
@@ -1,3 +1,4 @@
+{{ if .Values.publiclyExposed }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -14,3 +15,4 @@ spec:
   dnsNames:
   - navidrome.{{ include "baseDomain" . }}
   - navidrome-uploader.{{ include "baseDomain" . }}
+{{ end }}

--- a/charts/navidrome-deployer/templates/clusterissuer.yml
+++ b/charts/navidrome-deployer/templates/clusterissuer.yml
@@ -1,3 +1,4 @@
+{{ if .Values.publiclyExposed }}
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
@@ -19,3 +20,4 @@ spec:
     - http01:
         ingress:
           class: traefik
+{{ end }}

--- a/charts/navidrome-deployer/templates/filebrowser/service.yml
+++ b/charts/navidrome-deployer/templates/filebrowser/service.yml
@@ -13,6 +13,9 @@ spec:
   ports:
     - port: {{ .Values.filebrowser.service.port }}
       targetPort: {{ .Values.filebrowser.containerPort }}
+      {{ if eq .Values.filebrowser.service.type "NodePort" }}
+      nodePort: {{ .Values.filebrowser.service.port }}
+      {{ end }}
       protocol: TCP
       name: http
   selector:

--- a/charts/navidrome-deployer/templates/filebrowser/service.yml
+++ b/charts/navidrome-deployer/templates/filebrowser/service.yml
@@ -7,6 +7,9 @@ metadata:
     {{- include "commonLabels" . | nindent 4 }}
     {{- include "appLabels" . | nindent 4 }}
 spec:
+  {{ if .Values.filebrowser.service.type }}
+  type: {{ .Values.filebrowser.service.type }}
+  {{ end }}
   ports:
     - port: {{ .Values.filebrowser.service.port }}
       targetPort: {{ .Values.filebrowser.containerPort }}

--- a/charts/navidrome-deployer/templates/ingressroute.yml
+++ b/charts/navidrome-deployer/templates/ingressroute.yml
@@ -1,3 +1,4 @@
+{{ if .Values.publiclyExposed }}
 apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
@@ -28,3 +29,4 @@ spec:
           port: 80
   tls:
     secretName: {{ .Values.certificate.secret }}
+{{ end }}

--- a/charts/navidrome-deployer/templates/middleware.yml
+++ b/charts/navidrome-deployer/templates/middleware.yml
@@ -1,3 +1,4 @@
+{{ if .Values.publiclyExposed }}
 apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
@@ -28,3 +29,4 @@ spec:
   rateLimit:
     average: 50
     burst: 200
+{{ end }}

--- a/charts/navidrome-deployer/templates/service.yml
+++ b/charts/navidrome-deployer/templates/service.yml
@@ -13,6 +13,9 @@ spec:
   ports:
     - port: {{ .Values.service.port }}
       targetPort: {{ .Values.containerPort }}
+      {{ if eq .Values.service.type "NodePort" }}
+      nodePort: {{ .Values.service.port }}
+      {{ end }}
       protocol: TCP
       name: http
   selector:

--- a/charts/navidrome-deployer/templates/service.yml
+++ b/charts/navidrome-deployer/templates/service.yml
@@ -7,6 +7,9 @@ metadata:
     {{- include "commonLabels" . | nindent 4 }}
     {{- include "appLabels" . | nindent 4 }}
 spec:
+  {{ if .Values.service.type }}
+  type: {{ .Values.service.type }}
+  {{ end }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: {{ .Values.containerPort }}

--- a/charts/navidrome-deployer/values.yaml
+++ b/charts/navidrome-deployer/values.yaml
@@ -13,9 +13,10 @@ resources:
 
 # Service configuration
 service:
-  type: LoadBalancer
   port: 80
 
+# use public endpoints configuration only if the following is true
+publiclyExposed: true
 # Public endpoints configuration
 baseDomain: "example.com"
 clusterissuer:

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -39,7 +39,7 @@ releases:
 - name: navidrome
   namespace: navidrome-system
   chart: navidrome/navidrome-deployer
-  version: 0.21.2
+  version: 0.22.0
   createNamespace: true
   disableValidationOnInstall: true
   needs:

--- a/scripts/local-deployment.sh
+++ b/scripts/local-deployment.sh
@@ -4,6 +4,7 @@ set -ex
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 
 source "$SCRIPT_DIR/test-setup.sh"
+export KUBECONFIG='/etc/rancher/k3s/k3s.yaml'
 source "$SCRIPT_DIR/longhorn-preflight.sh"
 
 # build the filebrowser-reconfig image

--- a/scripts/test-setup.sh
+++ b/scripts/test-setup.sh
@@ -23,5 +23,6 @@ fi
 sudo curl -sfL https://get.k3s.io | sh -s - server \
     --disable-cloud-controller \
     --disable=servicelb \
+    --disable=metrics-server \
     --etcd-disable-snapshots
 sudo chmod 644 /etc/rancher/k3s/k3s.yaml


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a `publiclyExposed` flag to control Navidrome’s public endpoints. When false, the chart skips `traefik` ingress and `cert-manager` certs to keep the service internal.

- **New Features**
  - Gate IngressRoute, Middleware, ClusterIssuer, and Certificate with `publiclyExposed`.
  - Make `service.type` optional for Navidrome and Filebrowser; defaults to ClusterIP when unset.
  - When `service.type` is `NodePort`, set `nodePort` to the service port for Navidrome and Filebrowser.
  - Bump chart to 0.22.0 and update `helmfile` release.
  - Local scripts: export `KUBECONFIG`; disable `metrics-server` in `k3s` setup.

- **Migration**
  - To keep Navidrome private: set `publiclyExposed: false`.
  - Set `service.type` as needed (`ClusterIP`, `NodePort`, `LoadBalancer`). For `NodePort`, the `nodePort` equals the service port.

<sup>Written for commit e1c9e180284e1fdc5c3a0044d41473e8b8abaeb0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/semmet95/navidrome-deployer/pull/63?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

